### PR TITLE
bump burns-audio WAMs, write plugin path directly to index.js

### DIFF
--- a/example/server.js
+++ b/example/server.js
@@ -16,6 +16,7 @@ ${Plugins.map(p => `<a href="/plugins/${p.path}/index.js">${p.name}</a>`).join("
 app.use("/plugins", express.static('../dist/plugins',{
     setHeaders: function(res, path) {
         res.set("Access-Control-Allow-Origin", "*");
+        res.set("Cross-Origin-Resource-Policy", "cross-origin")
     }
 }))
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,17 @@
+export type Plugin = {
+  name: string
+  vendor: string
+  website: string
+  description: string
+  keywords: string[]
+  category: string[]
+  path: string
+};
+
+export declare const Plugins: Plugin[]
+export declare const Keywords: string[]
+export declare const Categories: Record<string, string[]>
+export declare const Vendors: string[]
+
+export {};
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wam-community",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "A collection of prebuilt Web Audio Modules ready for use",
   "main": "dist/index.js",
   "type": "module",
@@ -28,7 +28,7 @@
   },
   "homepage": "https://github.com/boourns/wam-community#readme",
   "devDependencies": {
-    "burns-audio-wam": "^0.2.28",
+    "burns-audio-wam": "^0.2.30",
     "glob": "^8.0.3"
   }
 }

--- a/tools/build.js
+++ b/tools/build.js
@@ -82,3 +82,5 @@ export default WAMCommunity;
 
 `
 writeFileSync("./dist/index.js", code)
+
+cpSync("./index.d.ts", `./dist/index.d.ts`)

--- a/tools/src/plugin.js
+++ b/tools/src/plugin.js
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { existsSync, readFileSync } from 'fs'
 import { basename } from 'path'
 
 const categories = JSON.parse(readFileSync('./categories.json'))["categories"]
@@ -26,6 +26,12 @@ const validateDescriptor = (descriptor) => {
  * processPlugin validates a single plugin entry
  */
 const processPlugin = ((dir, plugin) => {
+    console.log(`${dir}/${plugin.path}: Confirming entry point exists`)
+    const entryPoint = `${dir}/${plugin.path}/index.js`
+    if (!existsSync(entryPoint)) {
+        throw new Error(`Expected WAM entrypoint does not exist: ${entryPoint}`)
+    }
+
     console.log(`${dir}/${plugin.path}: Validating category`)
     validateCategory(plugin)
     
@@ -42,7 +48,7 @@ const processPlugin = ((dir, plugin) => {
         category: plugin.category,
         thumbnail: plugin.thumbnail,
         version: plugin.version,
-        path: `${basename(dir)}/${plugin.path}`
+        path: `${basename(dir)}/${plugin.path}/index.js`
     }
 
     return entry

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,10 +21,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"burns-audio-wam@npm:^0.2.28":
-  version: 0.2.28
-  resolution: "burns-audio-wam@npm:0.2.28"
-  checksum: ff895f4ac621ae59b198d56f9ab6090e86f9c253d4989309042481687d0f837a59ff68b3d26ca77cd7470abe0d8782d7fb8b43c9ce19647fb2515600a8f0f9d0
+"burns-audio-wam@npm:^0.2.30":
+  version: 0.2.30
+  resolution: "burns-audio-wam@npm:0.2.30"
+  checksum: ebbdbe3a2ef4c2ac8df955e0072f7d03940eb69e2ec99766a451aff1303a9ed8ff6f5b5500c915e025b221d50ec82a3e742ed0971da6753cf1defd38d317ac98
   languageName: node
   linkType: hard
 
@@ -87,7 +87,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "wam-community@workspace:."
   dependencies:
-    burns-audio-wam: ^0.2.28
+    burns-audio-wam: ^0.2.30
     glob: ^8.0.3
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
easier for hosts if `plugin.path` points directly to the entry-point, in case eventually we support WAMs without `index.js` entry points.